### PR TITLE
Add support for size 12 and 16 and improve header generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The script offers a command line interface with somehow self-describing argument
       --ascii               Convert for all ascii characters (overrides -c and -C)
       --font FONT           Define Font Name to be processed. Name should include modifier like Bold or Italic. If none
                             is given, all fonts in folder will be processed.
-      -s {8,24,32,40,48,56,64,all}, --fontsize {8,24,32,40,48,56,64,all}
+      -s {8,12,16,24,32,40,48,56,64,all}, --fontsize {8,12,16,24,32,40,48,56,64,all}
                             Fontsize (Fontheight) in pixels. Default: 32
       --variable_width      Variable width of characters.
       --progmem             C Variable declaration adds PROGMEM to character arrays. Useful to store the characters in

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The script offers a command line interface with somehow self-describing argument
                             porgram memory for AVR Microcontrollers with limited Flash or EEprom
       -p, --print_ascii     Print each character as ASCII Art on commandline, for debugging
       --square              Make the font square instead of height by (height * 0.75)
+      --struct              Wrap de generated fonts data in a struct
 
 The program can also be run directly on Linux systems by doing `./ttf2bmh.py`
 

--- a/src/ttf2bmh.py
+++ b/src/ttf2bmh.py
@@ -142,7 +142,7 @@ def main():
             Font = fm.decode('utf-8')
             Font = re.sub('\x00','',Font)
 
-            output_bmh_folder = os.path.join(output_folder, Font)
+            output_bmh_folder = os.path.join(output_folder, Font.replace(' ', '_'))
             if not (os.path.exists(output_bmh_folder)):
                 os.mkdir(output_bmh_folder)
 
@@ -161,7 +161,7 @@ def main():
                     yoffset = font_yoffsets[height_idx]
 
                 # Filename Definitions
-                filename = Font + '_' + str(height) # General Filename
+                filename = Font.replace(' ', '_') + '_' + str(height) # General Filename
                 h_filename = os.path.join(output_bmh_folder, filename + '.h') # Outputfile for font
                 png_filename = os.path.join(output_bmh_folder, filename + '.png') # Outputfile for font
 

--- a/src/ttf2bmh.py
+++ b/src/ttf2bmh.py
@@ -186,10 +186,13 @@ def main():
                     # Calculate byte arrays and write to file
 
                     if(variable_width):
-                        # TODO: Fix zero with chars like the space ' '
                         [zero_col_cnt_left, zero_col_cnt_right] = calculate_char_width(image, width, height)
                         char_width = width - zero_col_cnt_right - zero_col_cnt_left
-                        x_offset = zero_col_cnt_left
+                        if(char_width > 0):
+                            x_offset = zero_col_cnt_left
+                        else:
+                            char_width = 1
+                            x_offset = 0
                     else:
                         char_width = width
                         x_offset = 0
@@ -372,6 +375,8 @@ def write_bmh_head(h_filename, Font):
 
     outfile.write("#pragma once\n\n")
 
+    outfile.write("#include <stdint.h>\n\n")
+
     outfile.write("// Header File for characters\n")
     outfile.write("// Generated with TTF2BMH\n")
     outfile.write("// Font " +  Font + "\n")
@@ -383,14 +388,14 @@ def write_bmh_head(h_filename, Font):
 def write_bmh_char(outfile, char, dot_array, progmem):
     # C Type declaration strings
     # Adjust for different MCU/compilers
-    C_declaration_0 = 'const char bitmap_'
+    C_declaration_0 = 'const uint8_t bitmap_'
     if(progmem):
         C_declaration_1 = '[] PROGMEM = {'
     else:
         C_declaration_1 = '[] = {'
 
-    dot_array_hex_string = [bin(int(value)) for value in dot_array]
-    C_mem_array = (','.join(dot_array_hex_string))
+    dot_array_string = [bin(int(value)) for value in dot_array]
+    C_mem_array = (','.join(dot_array_string))
     C_printline = C_declaration_0 + str(ord(char)) + C_declaration_1 + C_mem_array +'}; // \'' + char + '\'\n'
 
     #print(C_printline)
@@ -399,7 +404,7 @@ def write_bmh_char(outfile, char, dot_array, progmem):
 #---------------------------------------------------------------------------------------
 # Write BMH Tail and close file
 def write_bmh_tail(outfile, width_array, character_line, height):
-    C_char_width_0 = 'const char char_width[] = {'
+    C_char_width_0 = 'const uint8_t char_width[] = {'
     C_char_width_1 = (','.join(width_array))
     C_char_width_2 = '};\n'
 
@@ -408,11 +413,11 @@ def write_bmh_tail(outfile, width_array, character_line, height):
     C_addr_array = []
     C_available_chars_array = []
     for char in character_line:
-        C_addr_array.append('&bitmap_' + str(ord(char)))
+        C_addr_array.append('&bitmap_' + str(ord(char)) + "[0]")
         C_available_chars_array.append(str(ord(char)))
 
     C_addr  = (','.join(C_addr_array))
-    C_address_declaration_1 = "const char* char_addr[] = {"
+    C_address_declaration_1 = "const uint8_t* char_addr[] = {"
     C_address_declaration_2 = "};\n"
 
     outfile.write(C_address_declaration_1 + C_addr + C_address_declaration_2)
@@ -423,11 +428,11 @@ def write_bmh_tail(outfile, width_array, character_line, height):
 
     outfile.write(C_available_chars_declaration_1 + C_available_chars + C_available_chars_declaration_2)
     
-    outfile.write("const char char_count = " + str(len(character_line)) + ";\n")
-    outfile.write("const char font_size = " + str(height) + ";\n")
+    outfile.write("const uint8_t char_count = " + str(len(character_line)) + ";\n")
+    outfile.write("const uint8_t font_size = " + str(height) + ";\n")
 
     (bytes_in_height, top_padding) = get_y_bytes_and_top_padding(height)
-    outfile.write("const char top_padding = " + str(top_padding) + ";\n")
+    outfile.write("const uint8_t top_padding = " + str(top_padding) + ";\n")
 
     outfile.close()
 

--- a/src/ttf2bmh.py
+++ b/src/ttf2bmh.py
@@ -38,8 +38,9 @@ from shutil import copyfile
 from fontTools import ttLib
 from PIL import Image, ImageFont, ImageDraw
 import argparse
+import math
 
-VERSION = '2.1'
+VERSION = '2.2'
 
 # Tab to iterate over Font Files in specific directory
 def main():
@@ -53,14 +54,14 @@ def main():
     parser.add_argument('-C','--characters', type=str, help='String of characters to be processed (if no character_filename passed in)')
     parser.add_argument('--ascii', action='store_true', help='Convert for all ascii characters (overrides -c and -C)')
     parser.add_argument('--font', default = '', help='Define Font Name to be processed. Name should include modifier like Bold or Italic. If none is given, all fonts in folder will be processed.')
-    parser.add_argument('-s','--fontsize', default='32', choices=['8','24', '32', '40', '48', '56', '64', 'all'], help='Fontsize (Fontheight) in pixels. Default: 32')
+    parser.add_argument('-s','--fontsize', default='32', choices=['8', '12', '16', '24', '32', '40', '48', '56', '64', 'all'], help='Fontsize (Fontheight) in pixels. Default: 32')
     parser.add_argument('-O','--offset', type=int, help='Y Offset for characters (Default is based off font size)')
     parser.add_argument('--variable_width', default=False, action='store_true', help='Variable width of characters.')
     parser.add_argument('-fh','--font_height', help='Define fontsize of rendered font within the defined pixel image boundary')
     parser.add_argument('-y','--y_offset', help='Define starting offset of character. Only meaningful if specific fontsize is rendered.')
     parser.add_argument('--progmem',dest='progmem', default=False, action='store_true',help='C Variable declaration adds PROGMEM to character arrays. Useful to store the characters in porgram memory for AVR Microcontrollers with limited Flash or EEprom')
     parser.add_argument('-p','--print_ascii',dest='print_ascii', default=False, action='store_true',help='Print each character as ASCII Art on commandline, for debugging')
-    parser.add_argument('--square', default=False, action='store_true',help='Make the font square instead of height by (height * 0.75)')
+    parser.add_argument('--square', default=False, action='store_true',help='Make the font square instead of height by (height * 1.5)')
     args = parser.parse_args()
 
     if sys.platform == 'linux' and args.ttf_folder == "C:\\Windows\\Fonts\\":
@@ -102,8 +103,8 @@ def main():
 
 
         # Definition of Font Heights and offsets
-        font_heights = [8, 24, 32, 40, 48, 56, 64]
-        font_yoffsets = [0, 6, 5, 7, 8, 9, 10]
+        font_heights  = [8, 12, 16, 24, 32, 40, 48, 56, 64]
+        font_yoffsets = [0, 3 , 3 , 6 , 5 , 7 , 8 , 9 , 10]
 
         if(args.fontsize == 'all'):
             height_indices = range(len(font_heights))
@@ -111,23 +112,19 @@ def main():
             height_indices = [font_heights.index(int(args.fontsize))]
 
         if args.ascii:
-            chars = []
             character_line = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-            [chars.append(x) for x in character_line if x not in chars]
-            character_line = "".join(chars)
         elif args.character_filename is not None:
             # Read characters from file
-            [character_line,chars] = read_character_file(args.character_filename)
+            char_file = open(args.character_filename,'r')
+            character_line = char_file.read().replace("\n", "")
         elif args.characters is not None:
             # Read characters from command line
-            chars = []
             character_line = args.characters
-            [chars.append(x) for x in character_line if x not in chars]
-            character_line = "".join(chars)
         else:
             # Defaults to all numbers + colon if no chars given
             character_line = "0123456789:"
-            chars = ['0','1','2','3','4','5','6','7','8','9',':']
+
+        [character_line, chars] = get_chars_array(character_line)
 
         print("Converting characters: \"" + character_line + "\"")
 
@@ -157,7 +154,7 @@ def main():
                 if args.square:
                     width = height
                 else:
-                    width = int(height * 0.75)
+                    width = int(height * 1.5)
                 if args.offset is not None:
                     yoffset = args.offset
                 else:
@@ -178,7 +175,7 @@ def main():
                 PILfont = ImageFont.truetype(ttf_absolute_filename, font_height)
 
                 # Open BMH file and start writing
-                outfile = write_bmh_head(h_filename, Font, height)
+                outfile = write_bmh_head(h_filename, Font)
 
                 for char in chars:
                     # Create pixel image with PIL
@@ -189,6 +186,7 @@ def main():
                     # Calculate byte arrays and write to file
 
                     if(variable_width):
+                        # TODO: Fix zero with chars like the space ' '
                         [zero_col_cnt_left, zero_col_cnt_right] = calculate_char_width(image, width, height)
                         char_width = width - zero_col_cnt_right - zero_col_cnt_left
                         x_offset = zero_col_cnt_left
@@ -202,10 +200,11 @@ def main():
                     write_bmh_char(outfile, char, dot_array, progmem)
                     if(print_ascii):
                         print(char + ":")
-                        print_char(image, height, char_width, x_offset)
+                        #print_char(image, height, char_width, x_offset)
+                        print_char_from_h_file(dot_array, char_width)
 
                 # write tail and close bmh file
-                write_bmh_tail(outfile, width_array, character_line)
+                write_bmh_tail(outfile, width_array, character_line, height)
                 # write Image picture with all characters
                 write_pic_file(character_line, PILfont, width, height, png_filename)
                 if(len(TTF_FILES)<20):
@@ -288,14 +287,24 @@ def write_pic_file(character_line, PILfont, width, height, png_filename):
 
 #---------------------------------------------------------------------------------------
 # Calculate full pixels from image
+def get_y_bytes_and_top_padding(height):
+    bytes_in_height = int(math.ceil(height/8))
+    top_padding = (bytes_in_height * 8) - height
+
+    return (bytes_in_height, top_padding)
+
+#---------------------------------------------------------------------------------------
+# Calculate full pixels from image
 def get_pixel_byte(image, height, char_width, x_offset):
     dot_threshold = 127
     dot_array = []
-    for y_s in range(int(height/8)):
+    (bytes_in_height, top_padding) = get_y_bytes_and_top_padding(height)
+    for y_s in range(bytes_in_height):
+        start_index = top_padding if (y_s == 0) else 0
         for x_s in range(char_width):
             dot_byte = 0
-            for k in range(8):
-                bmf_s = image.getpixel(((x_s + x_offset), (y_s * 8 + k)))
+            for k in range(start_index, 8):
+                bmf_s = image.getpixel(((x_s + x_offset), (y_s * 8 + k - top_padding)))
                 if(bmf_s < dot_threshold):
                     dot_byte = dot_byte + 2**k
             dot_array.append(str(dot_byte))
@@ -338,11 +347,10 @@ def calculate_char_width(image, width, height):
 
 #---------------------------------------------------------------------------------------
 # Read character file
-def read_character_file(char_filename):
+def get_chars_array(character_line):
     chars = []
-    char_file = open(char_filename,'r')
-    character_line = char_file.read().replace("\n", "")
     [chars.append(x) for x in character_line if x not in chars]
+    chars.sort()
     character_line = "".join(chars)
 
     return [character_line,chars]
@@ -358,16 +366,16 @@ def search_ttf_folder(ttf_searchfolder):
     return TTF_FILES
 
 #---------------------------------------------------------------------------------------
-def write_bmh_head(h_filename, Font, height):
+def write_bmh_head(h_filename, Font):
 # Process BMF array and create header file to be used with any C compiler
     outfile = open(h_filename,"w+")
 
-    outfile.write("// Header File for SSD1306 characters\n")
+    outfile.write("#pragma once\n\n")
+
+    outfile.write("// Header File for characters\n")
     outfile.write("// Generated with TTF2BMH\n")
     outfile.write("// Font " +  Font + "\n")
 
-    #print('Font: ' + Font + ', Size:' + str(height))
-    outfile.write("// Font Size: " + str(height) + "\n")
     return outfile
 
 #---------------------------------------------------------------------------------------
@@ -381,30 +389,45 @@ def write_bmh_char(outfile, char, dot_array, progmem):
     else:
         C_declaration_1 = '[] = {'
 
-    C_mem_array = (','.join(dot_array))
-    C_printline = C_declaration_0 + str(ord(char)) + C_declaration_1 + C_mem_array +'};\n'
+    dot_array_hex_string = [bin(int(value)) for value in dot_array]
+    C_mem_array = (','.join(dot_array_hex_string))
+    C_printline = C_declaration_0 + str(ord(char)) + C_declaration_1 + C_mem_array +'}; // \'' + char + '\'\n'
 
     #print(C_printline)
     outfile.write(C_printline)
 
 #---------------------------------------------------------------------------------------
 # Write BMH Tail and close file
-def write_bmh_tail(outfile, width_array, character_line):
-    C_addr_array = []
+def write_bmh_tail(outfile, width_array, character_line, height):
     C_char_width_0 = 'const char char_width[] = {'
     C_char_width_1 = (','.join(width_array))
     C_char_width_2 = '};\n'
 
     outfile.write(C_char_width_0 + C_char_width_1 + C_char_width_2)
 
+    C_addr_array = []
+    C_available_chars_array = []
     for char in character_line:
         C_addr_array.append('&bitmap_' + str(ord(char)))
+        C_available_chars_array.append(str(ord(char)))
 
     C_addr  = (','.join(C_addr_array))
     C_address_declaration_1 = "const char* char_addr[] = {"
     C_address_declaration_2 = "};\n"
 
     outfile.write(C_address_declaration_1 + C_addr + C_address_declaration_2)
+
+    C_available_chars  = (','.join(C_available_chars_array))
+    C_available_chars_declaration_1 = "const char available_chars[] = {"
+    C_available_chars_declaration_2 = "};\n"
+
+    outfile.write(C_available_chars_declaration_1 + C_available_chars + C_available_chars_declaration_2)
+    
+    outfile.write("const char char_count = " + str(len(character_line)) + ";\n")
+    outfile.write("const char font_size = " + str(height) + ";\n")
+
+    (bytes_in_height, top_padding) = get_y_bytes_and_top_padding(height)
+    outfile.write("const char top_padding = " + str(top_padding) + ";\n")
 
     outfile.close()
 
@@ -432,6 +455,7 @@ def logfile_close(log_file):
 #---------------------------------------------------------------------------------------
 # print pixel array as ASCII Art
 def print_char(image, height, char_width, x_offset):
+    print("As saved in the image:")
     dot_threshold = 128
     for y_s in range(height):
         ascii_bmp = ''
@@ -442,6 +466,24 @@ def print_char(image, height, char_width, x_offset):
             else:
                 ascii_bmp = ascii_bmp + '.'
         print(ascii_bmp)
+    print(' ')
+    return 0
+
+#---------------------------------------------------------------------------------------
+# print pixel array as ASCII Art
+def print_char_from_h_file(dot_array, char_width):
+    print("As saved in the header file:")
+    height_bytes = int(len(dot_array)/char_width)
+    for y_s in range(height_bytes):
+        for k in range(8):
+            ascii_bmp = ''
+            for x_s in range(char_width):
+                bmf_s = int(dot_array[y_s * char_width + x_s]) & 2**(k)
+                if (bmf_s):
+                    ascii_bmp = ascii_bmp + '#'
+                else:
+                    ascii_bmp = ascii_bmp + '.'
+            print(ascii_bmp)
     print(' ')
     return 0
 #---------------------------------------------------------------------------------------


### PR DESCRIPTION
- Used the '{' character to determine the offset in `font_yoffsets`
- Added the function `print_char_from_h_file(...)` for better debugging and insight
- Add padding to the top if required in the case where the size is not divisible by 8
- Increase default width factor from 0.75 to 1.5 to fully support wide characters like 'w'
- Cleaning up the generation of the `chars` array.
- Add helper data in the generated header file
- Replace `' '` with `'_'` in font names when creating the output folder and header/png file.
- Use `uint8_t` rather than `char`
- Avoid zero-sized arrays by forcing a minimum character width of 1
- Add the `--struct` option to generate a struct around the generated data